### PR TITLE
Created a seperate fullscreen check / translation updates

### DIFF
--- a/src/livelywpf/UserControls/livelysettings/SettingsPage.xaml
+++ b/src/livelywpf/UserControls/livelysettings/SettingsPage.xaml
@@ -81,6 +81,13 @@
                             </ComboBox>
                             <TextBlock Margin="0,10,0,0" FontSize="12" TextWrapping="Wrap" Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}" Text="{x:Bind UIText.TipPerfAppFullScreen}"/>
 
+                            <ComboBox Header="{x:Bind UIText.TitlePerfAppMaximized}" Margin="0,10,0,0" MinWidth="200" SelectedIndex="{Binding SelectedAppMaximizedIndex, Mode=TwoWay}">
+                                <ComboBoxItem Content="{x:Bind UIText.TextPerfPause}"/>
+                                <ComboBoxItem Content="{x:Bind UIText.TextPerfNone}"/>
+                                <ComboBoxItem IsEnabled="False" Content="{x:Bind UIText.TextPerfKill}"/>
+                            </ComboBox>
+                            <TextBlock Margin="0,10,0,0" FontSize="12" TextWrapping="Wrap" Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}" Text="{x:Bind UIText.TipPerfAppMaximized}"/>
+                            
                             <ComboBox Header="{x:Bind UIText.TitlePerfAppFocused}" Margin="0,10,0,0" MinWidth="200" SelectedIndex="{Binding SelectedAppFocusIndex, Mode=TwoWay}">
                                 <ComboBoxItem Content="{x:Bind UIText.TextPerfPause}"/>
                                 <ComboBoxItem Content="{x:Bind UIText.TextPerfNone}"/>

--- a/src/livelywpf/UserControls/livelysettings/SettingsPage.xaml.cs
+++ b/src/livelywpf/UserControls/livelysettings/SettingsPage.xaml.cs
@@ -51,6 +51,8 @@ namespace livelysettings
         public string TitleWallpaperPlayback { get; set; }
         public string TitlePerfAppFullScreen { get; set; }
         public string TipPerfAppFullScreen { get; set; }
+        public string TitlePerfAppMaximized { get; set; }
+        public string TipPerfAppMaximized { get; set; }
         public string TitlePerfAppFocused { get; set; }
         public string TipPerfAppFocused { get; set; }
         public string TitlePerfBattery { get; set; }

--- a/src/livelywpf/livelywpf/Core/Wallpapers/ExtPrograms.cs
+++ b/src/livelywpf/livelywpf/Core/Wallpapers/ExtPrograms.cs
@@ -100,6 +100,8 @@ namespace livelywpf.Core
             }
             catch { }
             */
+
+            ProcessSuspend.SuspendAllThreads(this);
         }
 
         public void Play()
@@ -114,6 +116,7 @@ namespace livelywpf.Core
             }
             catch { }
             */
+            ProcessSuspend.ResumeAllThreads(this);
         }
 
         public void SetHWND(IntPtr hwnd)

--- a/src/livelywpf/livelywpf/Helpers/Pinvoke/NativeMethods.cs
+++ b/src/livelywpf/livelywpf/Helpers/Pinvoke/NativeMethods.cs
@@ -1431,6 +1431,16 @@ namespace livelywpf
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool IsZoomed(IntPtr hWnd);
 
+        public static bool IsForegroundFullScreen(IntPtr hWnd) {
+            GetWindowRect(hWnd, out RECT rect);
+            foreach (var screen in System.Windows.Forms.Screen.AllScreens) {
+                if (screen.Bounds.Width == (rect.Right - rect.Left) && screen.Bounds.Height == (rect.Bottom - rect.Top)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         [Flags]
         public enum SetWindowPosFlags : int
         {

--- a/src/livelywpf/livelywpf/Model/SettingsModel.cs
+++ b/src/livelywpf/livelywpf/Model/SettingsModel.cs
@@ -28,7 +28,7 @@ namespace livelywpf
         public bool IsFirstRun { get; set; }
         public bool ControlPanelOpened { get; set; }
         public AppRulesEnum AppFocusPause { get; set; }
-
+        public AppRulesEnum AppMaximizedPause { get; set; }
         public AppRulesEnum AppFullscreenPause { get; set; }
         public AppRulesEnum BatteryPause { get; set; }
 
@@ -105,6 +105,7 @@ namespace livelywpf
             IsFirstRun = true;
             ControlPanelOpened = false;
             AppFocusPause = AppRulesEnum.ignore;
+            AppMaximizedPause = AppRulesEnum.ignore;
             AppFullscreenPause = AppRulesEnum.pause;
             BatteryPause = AppRulesEnum.ignore;
             VideoPlayer = LivelyMediaPlayer.libmpvExt;

--- a/src/livelywpf/livelywpf/Properties/Resources.Designer.cs
+++ b/src/livelywpf/livelywpf/Properties/Resources.Designer.cs
@@ -1135,6 +1135,15 @@ namespace livelywpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Set what to do when a window is maximized or fullscreen.
+        /// </summary>
+        public static string TipAppMaximized {
+            get {
+                return ResourceManager.GetString("TipAppMaximized", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Set different wallpaper playback rules based on running application..
         /// </summary>
         public static string TipAppRules {
@@ -1396,6 +1405,15 @@ namespace livelywpf.Properties {
         public static string TitleAppFullScreen {
             get {
                 return ResourceManager.GetString("TitleAppFullScreen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Applications Maximized.
+        /// </summary>
+        public static string TitleAppMaximized {
+            get {
+                return ResourceManager.GetString("TitleAppMaximized", resourceCulture);
             }
         }
         

--- a/src/livelywpf/livelywpf/Properties/Resources.nl-NL.resx
+++ b/src/livelywpf/livelywpf/Properties/Resources.nl-NL.resx
@@ -520,7 +520,7 @@ Alle processen: Heavier, Scant alle processen om afspeelmogelijkheden te bepalen
     <value>Audio</value>
   </data>
   <data name="TitleAudioMaster" xml:space="preserve">
-    <value>Master Volume</value>
+    <value>Hoofd Volume</value>
   </data>
   <data name="TitleAudioPlayOnScreen" xml:space="preserve">
     <value>Speel audio af op scherm</value>
@@ -655,22 +655,22 @@ Alle processen: Heavier, Scant alle processen om afspeelmogelijkheden te bepalen
     <value>Met Windows opstarten</value>
   </data>
   <data name="TextWallpaperFitFill" xml:space="preserve">
-    <value>Fill</value>
+    <value>Vullen</value>
   </data>
   <data name="TextWallpaperFitNone" xml:space="preserve">
-    <value>None</value>
+    <value>Geen</value>
   </data>
   <data name="TextWallpaperFitUniform" xml:space="preserve">
     <value>Uniform</value>
   </data>
   <data name="TextWallpaperFitUniformToFill" xml:space="preserve">
-    <value>Uniform Fill</value>
+    <value>Uniform Vullen</value>
   </data>
   <data name="TipWallpaperFit" xml:space="preserve">
-    <value>Wallpaper scaling algorithm.</value>
+    <value>Wallpaper schaalings algoritme.</value>
   </data>
   <data name="TitleWallpaperFit" xml:space="preserve">
-    <value>Choose a fit</value>
+    <value>Kies een pasvorm</value>
   </data>
   <data name="TextPreviewWallpaper" xml:space="preserve">
     <value>Preview Wallpaper</value>
@@ -685,22 +685,22 @@ Alle processen: Heavier, Scant alle processen om afspeelmogelijkheden te bepalen
     <value>Show developer menu</value>
   </data>
   <data name="TextFileNotFound" xml:space="preserve">
-    <value>File not found</value>
+    <value>Bestand niet gevonden</value>
   </data>
   <data name="TextPicture" xml:space="preserve">
     <value>Picture</value>
   </data>
   <data name="TextUnsupportedFile" xml:space="preserve">
-    <value>File format not supported</value>
+    <value>Bestand wordt niet ondersteund</value>
   </data>
   <data name="TextProcessingWallpaper" xml:space="preserve">
     <value>Processing</value>
-  </data> 
+  </data>
   <data name="TextTitle" xml:space="preserve">
     <value>Title</value>
   </data>
   <data name="TextDescription" xml:space="preserve">
-    <value>Description</value>
+    <value>Beschrijving</value>
   </data>
   <data name="TextOK" xml:space="preserve">
     <value>OK</value>
@@ -709,7 +709,7 @@ Alle processen: Heavier, Scant alle processen om afspeelmogelijkheden te bepalen
     <value>Cancel</value>
   </data>
   <data name="TextCreatePreview" xml:space="preserve">
-    <value>Create Preview</value>
+    <value>Voorbeeld Genereren</value>
   </data>
   <data name="TitleGifPlayer" xml:space="preserve">
     <value>Gif Player</value>
@@ -718,16 +718,22 @@ Alle processen: Heavier, Scant alle processen om afspeelmogelijkheden te bepalen
     <value>Select the player used for gif wallpaper.</value>
   </data>
   <data name="TextFeatureMissing" xml:space="preserve">
-    <value>Some features are not available in this version of Lively.</value>
+    <value>Sommige functies zijn niet beschikbaar in deze Lively versie</value>
   </data>
-    <data name="TextControlPanelOpen" xml:space="preserve">
-    <value>Click here to manage wallpapers.</value>
+  <data name="TextControlPanelOpen" xml:space="preserve">
+    <value>Klik hier om u achtergronden te beheren.</value>
   </data>
-    <data name="TextStoreReview" xml:space="preserve">
-    <value>Do you enjoy using Lively? Leave a review :)</value>
+  <data name="TextStoreReview" xml:space="preserve">
+    <value>Bevalt Lively? Laat een review achter :)</value>
   </data>
   <data name="TitleStore" xml:space="preserve">
     <value>Store</value>
     <comment>For different version of Lively, example: Microsoft Store</comment>
-  </data>   
+  </data>
+  <data name="TipAppMaximized" xml:space="preserve">
+    <value>Stel in wat u wilt doen wanneer een applicatie venster is gemaximalizeerd.</value>
+  </data>
+  <data name="TitleAppMaximized" xml:space="preserve">
+    <value>Toepassingen gemaximalizeerd</value>
+  </data>
 </root>

--- a/src/livelywpf/livelywpf/Properties/Resources.resx
+++ b/src/livelywpf/livelywpf/Properties/Resources.resx
@@ -489,6 +489,9 @@ If still not working, close &amp; start Lively again/restart windows.
   <data name="TipAppFullScreen" xml:space="preserve">
     <value>Set what to do when fullscreen games/applications are running.</value>
   </data>
+  <data name="TipAppMaximized" xml:space="preserve">
+    <value>Set what to do when a window is maximized or fullscreen</value>
+  </data>
   <data name="TipAppRules" xml:space="preserve">
     <value>Set different wallpaper playback rules based on running application.</value>
   </data>
@@ -579,6 +582,9 @@ Edge is the built in webview of windows 10.</value>
   </data>
   <data name="TitleAppFullScreen" xml:space="preserve">
     <value>Applications Fullscreen</value>
+  </data>
+  <data name="TitleAppMaximized" xml:space="preserve">
+    <value>Applications Maximized</value>
   </data>
   <data name="TitleAppName" xml:space="preserve">
     <value>Lively Wallpaper</value>

--- a/src/livelywpf/livelywpf/ViewModel/SettingsViewModel.cs
+++ b/src/livelywpf/livelywpf/ViewModel/SettingsViewModel.cs
@@ -73,6 +73,7 @@ namespace livelywpf
 
             SelectedTileSizeIndex = Settings.TileSize;
             SelectedAppFullScreenIndex = (int)Settings.AppFullscreenPause;
+            SelectedAppMaximizedIndex = (int)Settings.AppMaximizedPause;
             SelectedAppFocusIndex = (int)Settings.AppFocusPause;
             SelectedBatteryPowerIndex = (int)Settings.BatteryPause;
             SelectedDisplayPauseRuleIndex = (int)Settings.DisplayPauseSettings;
@@ -333,6 +334,26 @@ namespace livelywpf
                 if(Settings.AppFullscreenPause != (AppRulesEnum)_selectedAppFullScreenIndex)
                 {
                     Settings.AppFullscreenPause = (AppRulesEnum)_selectedAppFullScreenIndex;
+                    UpdateConfigFile();
+                }
+            }
+        }
+
+        private int _selectedAppMaximizedIndex;
+        public int SelectedAppMaximizedIndex
+        {
+            get
+            {
+                return _selectedAppMaximizedIndex;
+            }
+            set
+            {
+                _selectedAppMaximizedIndex = value;
+                OnPropertyChanged("SelectedAppMaximizedIndex");
+
+                if (Settings.AppMaximizedPause != (AppRulesEnum)_selectedAppMaximizedIndex)
+                {
+                    Settings.AppMaximizedPause = (AppRulesEnum)_selectedAppMaximizedIndex;
                     UpdateConfigFile();
                 }
             }

--- a/src/livelywpf/livelywpf/Views/Main/SettingsView.xaml.cs
+++ b/src/livelywpf/livelywpf/Views/Main/SettingsView.xaml.cs
@@ -55,6 +55,8 @@ namespace livelywpf.Views
                     TitleWallpaperPlayback = Properties.Resources.TitleWallpaperPlayback,
                     TitlePerfAppFullScreen = Properties.Resources.TitleAppFullScreen,
                     TipPerfAppFullScreen = Properties.Resources.TipAppFullScreen,
+                    TitlePerfAppMaximized = Properties.Resources.TitleAppMaximized,
+                    TipPerfAppMaximized = Properties.Resources.TipAppMaximized,
                     TitlePerfAppFocused = Properties.Resources.TitleAppFocus,
                     TipPerfAppFocused = Properties.Resources.TipAppFocus,
                     TitlePerfBattery = Properties.Resources.TitleBatteryPower,


### PR DESCRIPTION
Created a separate performance entry for full-screen only instead of the combined maximized and or full-screen entry.

Original performance entry's still work as expected, I added this because personally separating them seemed more logical.
I moved the original full-screen function to the ApplicationsMaximized entry, and plugged the new check into the original full-screen entry.

Also updated/added some of the Dutch translations + the new lines for the maximized tab. 

And re-enabled the pausing of executable's, didn't notice any issues with Unity applications however if you think it needs more work it can be left out of the merge.

Edit:
Also changed a small spelling error in SetWallpapersVoume -> SetWallpapersVolume. 

Was not sure where to put suggestions so if this should have been an issue before a merge request feel free to tell me.