### PR TITLE
store badge fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
                     <li style="text-align: left;">
                       <h4>v2.0.2.1</h4>	
 										  <script type="module" src="https://getbadgecdn.azureedge.net/ms-store-badge.bundled.js"></script>
-                      <ms-store-badge productid="9NTM2QC6QWS7" size="large"></ms-store-badge>
+                      <ms-store-badge productid="9NTM2QC6QWS7" size="large" theme="dark"></ms-store-badge>
                     </li>
 									  <li style="flex-basis:100%;height: 1rem;"></li>	
                     <li class="DownloadBtn">


### PR DESCRIPTION
turns out there is an undocumented theme setting that can be force to dark or light.
It usally runs in auto but its giving the wrong result.