### PR TITLE
Change Open Lively icon (tray menu)

### DIFF
--- a/src/Lively/Lively/Systray.cs
+++ b/src/Lively/Lively/Systray.cs
@@ -75,7 +75,7 @@ namespace Lively
             _notifyIcon.ContextMenuStrip.Opening += ContextMenuStrip_Opening;
 
             //Show UI
-            _notifyIcon.ContextMenuStrip.Items.Add(Properties.Resources.TextOpenLively, Properties.Icons.icons8_application_window_96).Click += (s, e) => runner.ShowUI();
+            _notifyIcon.ContextMenuStrip.Items.Add(Properties.Resources.TextOpenLively, Properties.Icons.appicon_96).Click += (s, e) => runner.ShowUI();
             //Close wallpaper
             _notifyIcon.ContextMenuStrip.Items.Add(new ContextMenuTheme.StripSeparatorCustom().stripSeparator);
             _notifyIcon.ContextMenuStrip.Items.Add(Properties.Resources.TextCloseWallpapers, null).Click += (s, e) => desktopCore.CloseAllWallpapers(true);


### PR DESCRIPTION
This pr changes the icon of the Open Lively button in the tray context menu, but it's also an inquiry about why isn't the logo used for the button which opens the ui.
### Images
![image](https://github.com/rocksdanister/lively/assets/40339350/f98f3678-3d39-4e55-b29b-75f9089d21a6) -> ![image](https://github.com/rocksdanister/lively/assets/40339350/2bb0ed0f-2117-4b58-8b38-4192df62bb04)
_Is it because of the compression at the small size of the icon, or is there another reason?_