### PR TITLE
feat: add battery info to system data API (#1797)

### DIFF
--- a/src/Lively/Lively.Common.Services/HardwareUsageService.cs
+++ b/src/Lively/Lively.Common.Services/HardwareUsageService.cs
@@ -106,6 +106,7 @@ namespace Lively.Common.Services
                         {
                             //todo: log error.
                         }
+                        UpdateBatteryStatus();
                         HWMonitor?.Invoke(this, perfData);
                     }
                 });
@@ -117,6 +118,35 @@ namespace Lively.Common.Services
                 netDownCounter?.Dispose();
                 netUpCounter?.Dispose();
             }
+        }
+
+        private void UpdateBatteryStatus()
+        {
+            try
+            {
+                var sps = new PowerUtil.SystemPowerStatus();
+                if (PowerUtil.GetSystemPowerStatus(ref sps))
+                {
+                    perfData.BatteryPercent = sps._BatteryLifePercent;
+                    perfData.BatteryLifeTimeSeconds = sps._BatteryLifeTime;
+                    perfData.ACLineStatus = sps._ACLineStatus.ToString();
+                    perfData.BatteryState = GetBatteryStateString(sps._BatteryFlag);
+                    perfData.IsBatterySaverMode = sps._SystemStatusFlag == PowerUtil.SystemStatusFlag.On;
+                }
+            }
+            catch { }
+        }
+
+        private static string GetBatteryStateString(PowerUtil.BatteryFlag flag)
+        {
+            if (flag == PowerUtil.BatteryFlag.Unknown) return "Unknown";
+            if (flag == PowerUtil.BatteryFlag.NoSystemBattery) return "NoSystemBattery";
+            var states = new List<string>();
+            if ((flag & PowerUtil.BatteryFlag.Charging) != 0) states.Add("Charging");
+            if ((flag & PowerUtil.BatteryFlag.High) != 0) states.Add("High");
+            if ((flag & PowerUtil.BatteryFlag.Low) != 0) states.Add("Low");
+            if ((flag & PowerUtil.BatteryFlag.Critical) != 0) states.Add("Critical");
+            return states.Count > 0 ? string.Join(",", states) : "Unknown";
         }
 
         #region public helpers

--- a/src/Lively/Lively.Models/Services/HardwareUsageEventArgs.cs
+++ b/src/Lively/Lively.Models/Services/HardwareUsageEventArgs.cs
@@ -40,5 +40,25 @@ namespace Lively.Models.Services
         /// Full system ram amount (MegaBytes)
         /// </summary>
         public long TotalRam { get; set; }
+        /// <summary>
+        /// Battery charge percentage (0-100). Returns 255 if no battery present.
+        /// </summary>
+        public byte BatteryPercent { get; set; }
+        /// <summary>
+        /// Estimated remaining battery life in seconds. Returns -1 if unknown or plugged in.
+        /// </summary>
+        public int BatteryLifeTimeSeconds { get; set; }
+        /// <summary>
+        /// AC power status: "Online", "Offline" or "Unknown"
+        /// </summary>
+        public string ACLineStatus { get; set; }
+        /// <summary>
+        /// Battery state flags as string: "Charging", "High", "Low", "Critical", "NoSystemBattery" or "Unknown"
+        /// </summary>
+        public string BatteryState { get; set; }
+        /// <summary>
+        /// Whether battery saver mode is active.
+        /// </summary>
+        public bool IsBatterySaverMode { get; set; }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1797

Adds battery information to the `livelySystemInformation` system data API so wallpapers can react to battery state.

**New fields in `HardwareUsageEventArgs`:**
- `BatteryPercent` — charge level 0-100 (255 if no battery)
- `BatteryLifeTimeSeconds` — estimated seconds remaining (-1 if unknown/plugged in)
- `ACLineStatus` — `"Online"`, `"Offline"` or `"Unknown"`
- `BatteryState` — `"Charging"`, `"High"`, `"Low"`, `"Critical"`, `"NoSystemBattery"` or `"Unknown"`
- `IsBatterySaverMode` — `true` when battery saver is active

**Implementation:**
- Reuses existing `PowerUtil.GetSystemPowerStatus()` P/Invoke — no new dependencies
- Data is polled every ~1 second alongside CPU/RAM/GPU in `HWMonitorLoop()`
- Serialized automatically with existing JSON pipeline to all wallpaper players

**Wallpaper usage example:**
```javascript
window.addEventListener('livelySystemInformation', (data) => {
    console.log(data.BatteryPercent);       // 85
    console.log(data.ACLineStatus);         // "Offline"
    console.log(data.BatteryState);         // "Low"
    console.log(data.IsBatterySaverMode);   // true
});
```