### PR TITLE
Added smooth pausing for Wallpapers

### DIFF
--- a/src/Lively/Lively.Common/Helpers/WindowUtil.cs
+++ b/src/Lively/Lively.Common/Helpers/WindowUtil.cs
@@ -10,17 +10,17 @@ namespace Lively.Common.Helpers
 {
     public static class WindowUtil
     {
-        public static bool IsDisplayCoveredByWindowGrid(
+        public static double GetDisplayCoverageRatioByWindowGrid(
             List<IntPtr> topLevelWindows,
             Rectangle screenBounds,
             int tileSize = 50,
             double threshold = 0.05)
         {
             if (topLevelWindows is null || topLevelWindows.Count == 0)
-                return false;
+                return 0d;
 
             if (topLevelWindows.Exists(NativeMethods.IsZoomed))
-                return true;
+                return 1d;
 
             int width = screenBounds.Width;
             int height = screenBounds.Height;
@@ -36,7 +36,7 @@ namespace Lively.Common.Helpers
                     continue;
 
                 if (IsWindowCoveringTarget(rect, screenBounds, 0.95))
-                    return true;
+                    return 1d;
 
                 // Find overlapping tile indices
                 int xStart = Math.Max(0, (rect.Left - screenBounds.Left) / tileSize);
@@ -52,20 +52,64 @@ namespace Lively.Common.Helpers
                         {
                             covered[y, x] = true;
                             coveredCount++;
-
-                            if ((double)(totalTiles - coveredCount) / totalTiles <= threshold)
-                                return true;
                         }
                     }
                 }
             }
 
-            return false;
+            if (totalTiles == 0)
+                return 0d;
+
+            return coveredCount / (double)totalTiles;
+        }
+
+        public static bool IsDisplayCoveredByWindowGrid(
+            List<IntPtr> topLevelWindows,
+            Rectangle screenBounds,
+            int tileSize = 50,
+            double threshold = 0.05)
+        {
+            return GetDisplayCoverageRatioByWindowGrid(topLevelWindows, screenBounds, tileSize, threshold) >= 1d - threshold;
+        }
+
+        public static double GetDisplayCoverageRatioByAnyWindow(List<IntPtr> topLevelWindows, Rectangle screenBounds)
+        {
+            if (topLevelWindows is null || topLevelWindows.Count == 0)
+                return 0d;
+
+            double maxCoverage = 0d;
+            var targetAreaSize = (long)(screenBounds.Width * screenBounds.Height);
+            if (targetAreaSize <= 0)
+                return 0d;
+
+            foreach (var hwnd in topLevelWindows)
+            {
+                if (NativeMethods.IsZoomed(hwnd))
+                    return 1d;
+
+                if (NativeMethods.GetWindowRect(hwnd, out var rect) == 0 || IsEmpty(rect))
+                    continue;
+
+                var intersection = Rectangle.Intersect(ToRectangle(rect), screenBounds);
+                if (intersection.IsEmpty)
+                    continue;
+
+                var intersectionArea = (long)intersection.Width * intersection.Height;
+                var coverage = intersectionArea / (double)targetAreaSize;
+                if (coverage > maxCoverage)
+                {
+                    maxCoverage = coverage;
+                    if (maxCoverage >= 1d)
+                        return 1d;
+                }
+            }
+
+            return maxCoverage;
         }
 
         public static bool IsDisplayCoveredByAnyWindow(List<IntPtr> topLevelWindows, Rectangle screenBounds, double threshold = 0.95)
         {
-            return topLevelWindows.Exists(hwnd => IsDisplayCoveredByWindow(hwnd, screenBounds, threshold));
+            return GetDisplayCoverageRatioByAnyWindow(topLevelWindows, screenBounds) >= threshold;
         }
 
         public static bool IsDisplayCoveredByWindow(IntPtr hwnd, Rectangle screenBounds, double threshold = 0.95)

--- a/src/Lively/Lively.Grpc.Client/UserSettingsClient.cs
+++ b/src/Lively/Lively.Grpc.Client/UserSettingsClient.cs
@@ -287,6 +287,7 @@ namespace Lively.Grpc.Client
                     }
                 },
                 RestartAfterLockscreen = settings.IsRestartAfterLockscreen,
+                PauseSmoothingRange = settings.PauseSmoothingRange,
             };
         }
 
@@ -403,6 +404,7 @@ namespace Lively.Grpc.Client
                         settings.SelectedAudioOutputDisplay.WorkingArea.Height),
                 },
                 IsRestartAfterLockscreen = settings.RestartAfterLockscreen,
+                PauseSmoothingRange = settings.PauseSmoothingRange,
             };
         }
 

--- a/src/Lively/Lively.Grpc.Common/Proto/settings.proto
+++ b/src/Lively/Lively.Grpc.Common/Proto/settings.proto
@@ -84,6 +84,7 @@ message SettingsDataModel {
     GetScreensResponse selected_audio_output_display = 72;
     string visualizer_audio_device_id = 73;
     bool restart_after_lockscreen = 74;
+    double pause_smoothing_range = 75;
 }
 
 message AppRulesSettings {

--- a/src/Lively/Lively.Models/SettingsModel.cs
+++ b/src/Lively/Lively.Models/SettingsModel.cs
@@ -28,6 +28,7 @@ namespace Lively.Models
         public AppRules RemoteDesktopPause { get; set; }
         public AppRules PowerSaveModePause { get; set; }
         public DisplayPause DisplayPauseSettings { get; set; }
+        public double PauseSmoothingRange { get; set; }
         public ProcessMonitorAlgorithm ProcessMonitorAlgorithm { get; set; }
         /// <summary>
         /// Show animatd library tiles.
@@ -157,6 +158,7 @@ namespace Lively.Models
             AppFocusPause = AppRules.ignore;
             AppFullscreenPause = AppRules.pause;
             BatteryPause = AppRules.ignore;
+            PauseSmoothingRange = 0.15;
             VideoPlayer = LivelyMediaPlayer.mpv;
             VideoPlayerHwAccel = true;
             WebBrowser = LivelyWebBrowser.webview2;

--- a/src/Lively/Lively.UI.Shared/ViewModels/Settings/SettingsPerformanceViewModel.cs
+++ b/src/Lively/Lively.UI.Shared/ViewModels/Settings/SettingsPerformanceViewModel.cs
@@ -39,6 +39,7 @@ namespace Lively.UI.Shared.ViewModels
             SelectedPowerSaveModeIndex = (int)userSettings.Settings.PowerSaveModePause;
             SelectedDisplayPauseRuleIndex = (int)userSettings.Settings.DisplayPauseSettings;
             SelectedPauseAlgorithmIndex = (int)userSettings.Settings.ProcessMonitorAlgorithm;
+            PauseSmoothingRangePercent = userSettings.Settings.PauseSmoothingRange * 100d;
             //Only pause rules are shown to user, rest is internal use.
             AppRules = new ObservableCollection<ApplicationRulesModel>(userSettings.AppRules.Where(x => x.Rule == Models.Enums.AppRules.pause));
         }
@@ -166,6 +167,29 @@ namespace Lively.UI.Shared.ViewModels
                 SetProperty(ref _selectedPauseAlgorithmIndex, value);
             }
         }
+
+        private double _pauseSmoothingRangePercent;
+        public double PauseSmoothingRangePercent
+        {
+            get => _pauseSmoothingRangePercent;
+            set
+            {
+                if (Math.Abs(_pauseSmoothingRangePercent - value) < 0.01)
+                    return;
+
+                var clamped = Math.Clamp(value, 0d, 30d);
+                if (userSettings.Settings.PauseSmoothingRange != clamped / 100d)
+                {
+                    userSettings.Settings.PauseSmoothingRange = clamped / 100d;
+                    UpdateSettingsConfigFile();
+                }
+
+                if (SetProperty(ref _pauseSmoothingRangePercent, clamped))
+                    OnPropertyChanged(nameof(PauseSmoothingRangeText));
+            }
+        }
+
+        public string PauseSmoothingRangeText => $"{PauseSmoothingRangePercent:0}%";
 
         #region apprules
 

--- a/src/Lively/Lively.UI.WinUI/Views/Pages/Settings/SettingsPerformanceView.xaml
+++ b/src/Lively/Lively.UI.WinUI/Views/Pages/Settings/SettingsPerformanceView.xaml
@@ -160,6 +160,19 @@
                             <ComboBoxItem>Grid</ComboBoxItem>
                         </ComboBox>
                     </controls:SettingsCard>
+
+                    <controls:SettingsCard x:Uid="PauseSmoothingRange">
+                        <controls:SettingsCard.HeaderIcon>
+                            <FontIcon Glyph="&#xE8E5;" />
+                        </controls:SettingsCard.HeaderIcon>
+                        <StackPanel Spacing="8">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="SpaceBetween">
+                                <TextBlock x:Uid="PauseSmoothingRangeLabel" Text="Pause smoothing" />
+                                <TextBlock Text="{Binding PauseSmoothingRangeText, Mode=OneWay}" />
+                            </StackPanel>
+                            <Slider Minimum="0" Maximum="30" Value="{Binding PauseSmoothingRangePercent, Mode=TwoWay}" StepFrequency="1" />
+                        </StackPanel>
+                    </controls:SettingsCard>
                     <InfoBar
                         Title="?"
                         VerticalAlignment="Top"

--- a/src/Lively/Lively/Core/Suspend/Playback.cs
+++ b/src/Lively/Lively/Core/Suspend/Playback.cs
@@ -38,6 +38,11 @@ namespace Lively.Core.Suspend
         private bool isLockScreen, isRemoteSession;
         private bool disposedValue;
 
+        private readonly Dictionary<string, double> displayPauseProgress = new();
+        private readonly Dictionary<string, bool> displayPauseState = new();
+        private double globalPauseProgress;
+        private bool globalPauseState;
+
         private readonly IUserSettingsService userSettings;
         private readonly IDisplayManager displayManager;
         private readonly IScreensaverService screenSaver;
@@ -132,13 +137,17 @@ namespace Lively.Core.Suspend
                             EvaluatePlaybackByForegroundWindow();
                             break;
                         case ProcessMonitorAlgorithm.all:
-                            EvaluatePlaybackByVisibleWindow((display, windows) => WindowUtil.IsDisplayCoveredByAnyWindow(windows, display.WorkingArea));
+                            EvaluatePlaybackByVisibleWindow((display, windows) => (
+                                coverage: WindowUtil.GetDisplayCoverageRatioByAnyWindow(windows, display.WorkingArea),
+                                threshold: 0.95));
                             break;
                         case ProcessMonitorAlgorithm.grid:
-                            EvaluatePlaybackByVisibleWindow((display, windows) => WindowUtil.IsDisplayCoveredByWindowGrid(windows,
-                                display.WorkingArea,
-                                userSettings.Settings.ProcessMonitorGridTileSize,
-                                userSettings.Settings.ProcessMonitorGridTileCoverageThreshold));
+                            EvaluatePlaybackByVisibleWindow((display, windows) => (
+                                coverage: WindowUtil.GetDisplayCoverageRatioByWindowGrid(windows,
+                                    display.WorkingArea,
+                                    userSettings.Settings.ProcessMonitorGridTileSize,
+                                    userSettings.Settings.ProcessMonitorGridTileCoverageThreshold),
+                                threshold: 1d - userSettings.Settings.ProcessMonitorGridTileCoverageThreshold));
                             break;
                         case ProcessMonitorAlgorithm.gamemode:
                             EvaluatePlaybackByGameMode();
@@ -221,7 +230,7 @@ namespace Lively.Core.Suspend
             }
         }
 
-        private void EvaluatePlaybackByVisibleWindow(Func<DisplayMonitor, List<IntPtr>, bool> coverageCheck)
+        private void EvaluatePlaybackByVisibleWindow(Func<DisplayMonitor, List<IntPtr>, (double coverage, double threshold)> coverageCalculator)
         {
             var windows = WindowUtil.GetVisibleTopLevelWindows();
             if (windows.Exists(IsPauseRuleApp))
@@ -251,12 +260,11 @@ namespace Lively.Core.Suspend
                                     foreach (var display in displayManager.DisplayMonitors)
                                     {
                                         var windowsOnDisplay = monitorWindowsMap.GetValueOrDefault(display) ?? [];
-                                        var shouldPause = ShouldPauseWallpaper(display, windowsOnDisplay, coverageCheck);
+                                        var (coverage, threshold) = coverageCalculator(display, windowsOnDisplay);
+                                        var pauseProgress = UpdatePauseProgress(display.DeviceId, coverage, threshold);
+                                        var shouldPause = pauseProgress >= 0.75;
 
-                                        if (shouldPause)
-                                            PauseWallpaper(display);
-                                        else
-                                            PlayWallpaper(display);
+                                        UpdateDisplayPauseState(display, shouldPause);
                                     }
                                 }
                                 break;
@@ -265,7 +273,9 @@ namespace Lively.Core.Suspend
                                     var shouldPause = displayManager.DisplayMonitors.All(display =>
                                     {
                                         var windowsOnDisplay = monitorWindowsMap.GetValueOrDefault(display) ?? [];
-                                        return ShouldPauseWallpaper(display, windowsOnDisplay, coverageCheck);
+                                        var (coverage, threshold) = coverageCalculator(display, windowsOnDisplay);
+                                        var pauseProgress = UpdatePauseProgress(display.DeviceId, coverage, threshold);
+                                        return pauseProgress >= 0.75;
                                     });
 
                                     if (shouldPause)
@@ -279,16 +289,17 @@ namespace Lively.Core.Suspend
                     break;
                 case DisplayPause.all:
                     {
-                        var shouldPauseAll = displayManager.DisplayMonitors.Any(display =>
+                        var maxWeight = displayManager.DisplayMonitors.Max(display =>
                         {
                             var windowsOnDisplay = monitorWindowsMap.GetValueOrDefault(display) ?? [];
-                            return ShouldPauseWallpaper(display, windowsOnDisplay, coverageCheck);
+                            var (coverage, threshold) = coverageCalculator(display, windowsOnDisplay);
+                            return GetPauseWeight(coverage, threshold);
                         });
 
-                        if (shouldPauseAll)
-                            PauseWallpapers();
-                        else
-                            PlayWallpapers();
+                        var pauseProgress = UpdateGlobalPauseProgress(maxWeight);
+                        var shouldPauseAll = pauseProgress >= 0.75;
+
+                        UpdateGlobalPauseState(shouldPauseAll);
                     }
                     break;
             }
@@ -355,16 +366,99 @@ namespace Lively.Core.Suspend
             SetWallpaperVolume(userSettings.Settings.AudioVolumeGlobal);
         }
 
-        private bool ShouldPauseWallpaper(DisplayMonitor display, List<IntPtr> windowsOnDisplay, Func<DisplayMonitor, List<IntPtr>, bool> coverageCheck)
+        private bool ShouldPauseWallpaper(DisplayMonitor display, List<IntPtr> windowsOnDisplay, double coverageRatio, double pauseThreshold)
         {
             var isFullScreenPause = userSettings.Settings.AppFullscreenPause == AppRules.pause;
             var isFocusedAppPause = userSettings.Settings.AppFocusPause == AppRules.pause;
             var isDesktop = windowsOnDisplay.Count == 0;
-            var isCovered = coverageCheck(display, windowsOnDisplay);
 
-            // IsFullScreenPause = false, always play wallpaper
-            // IsFocusedAppPause = true, only play on desktop.
-            return isFullScreenPause && ((isFocusedAppPause && !isDesktop) || isCovered);
+            if (!isFullScreenPause)
+                return false;
+
+            if (isFocusedAppPause && !isDesktop)
+                return true;
+
+            var smoothingRange = GetPauseSmoothingRange();
+            var lowerThreshold = Math.Max(0d, pauseThreshold - smoothingRange);
+
+            if (coverageRatio >= pauseThreshold)
+                return true;
+
+            if (coverageRatio <= lowerThreshold)
+                return false;
+
+            var pauseWeight = (coverageRatio - lowerThreshold) / (pauseThreshold - lowerThreshold);
+            return pauseWeight >= 0.5;
+        }
+
+        private double GetPauseWeight(double coverageRatio, double pauseThreshold)
+        {
+            if (coverageRatio >= pauseThreshold)
+                return 1d;
+
+            var smoothingRange = GetPauseSmoothingRange();
+            var lowerThreshold = Math.Max(0d, pauseThreshold - smoothingRange);
+            if (coverageRatio <= lowerThreshold)
+                return 0d;
+
+            return (coverageRatio - lowerThreshold) / (pauseThreshold - lowerThreshold);
+        }
+
+        private double GetPauseSmoothingRange()
+        {
+            return Math.Clamp(userSettings.Settings.PauseSmoothingRange, 0d, 0.5d);
+        }
+
+        private double UpdatePauseProgress(string key, double coverageRatio, double pauseThreshold)
+        {
+            return UpdatePauseProgress(key, GetPauseWeight(coverageRatio, pauseThreshold));
+        }
+
+        private double UpdatePauseProgress(string key, double targetWeight)
+        {
+            if (!displayPauseProgress.TryGetValue(key, out var currentProgress))
+                currentProgress = 0d;
+
+            const double transitionSeconds = 0.8;
+            var step = Math.Min(1d, dispatcherTimer.Interval.TotalSeconds / transitionSeconds);
+            currentProgress += (targetWeight - currentProgress) * step;
+            currentProgress = Math.Clamp(currentProgress, 0d, 1d);
+            displayPauseProgress[key] = currentProgress;
+            return currentProgress;
+        }
+
+        private double UpdateGlobalPauseProgress(double targetWeight)
+        {
+            const double transitionSeconds = 0.8;
+            var step = Math.Min(1d, dispatcherTimer.Interval.TotalSeconds / transitionSeconds);
+            globalPauseProgress += (targetWeight - globalPauseProgress) * step;
+            globalPauseProgress = Math.Clamp(globalPauseProgress, 0d, 1d);
+            return globalPauseProgress;
+        }
+
+        private void UpdateDisplayPauseState(DisplayMonitor display, bool shouldPause)
+        {
+            var key = display.DeviceId;
+            if (displayPauseState.TryGetValue(key, out var isPaused) && isPaused == shouldPause)
+                return;
+
+            displayPauseState[key] = shouldPause;
+            if (shouldPause)
+                PauseWallpaper(display);
+            else
+                PlayWallpaper(display);
+        }
+
+        private void UpdateGlobalPauseState(bool shouldPause)
+        {
+            if (globalPauseState == shouldPause)
+                return;
+
+            globalPauseState = shouldPause;
+            if (shouldPause)
+                PauseWallpapers();
+            else
+                PlayWallpapers();
         }
 
         private void PauseWallpapers()

--- a/src/Lively/Lively/RPC/UserSettingsServer.cs
+++ b/src/Lively/Lively/RPC/UserSettingsServer.cs
@@ -179,6 +179,7 @@ namespace Lively.RPC
             userSettings.Settings.CefDiskCache = req.CefDiskCache;
             userSettings.Settings.DebugMenu = req.DebugMenu;
             userSettings.Settings.IsBetaOptIn = req.TestBuild;
+            userSettings.Settings.PauseSmoothingRange = req.PauseSmoothingRange;
             userSettings.Settings.ApplicationTheme = (Models.Enums.AppTheme)req.ApplicationTheme;
             userSettings.Settings.RemoteDesktopPause = (Models.Enums.AppRules)req.RemoteDesktopPause;
             userSettings.Settings.PowerSaveModePause = (Models.Enums.AppRules)req.PowerSaveModePause;
@@ -319,6 +320,7 @@ namespace Lively.RPC
                 ScreensaverFadeIn = settings.ScreensaverFadeIn,
                 VideoTargetColorSpaceMode = (TargetColorSpaceMode)settings.VideoTargetColorSpaceMode,
                 VisualizerAudioDeviceId = settings.VisualizerAudioDeviceId ?? string.Empty,
+                PauseSmoothingRange = settings.PauseSmoothingRange,
                 DisplayAudioOutput = (Grpc.Common.Proto.Settings.DisplayAudioMode)settings.DisplayAudioOutput,
                 SelectedAudioOutputDisplay = new GetScreensResponse()
                 {


### PR DESCRIPTION
Title
Expose wallpaper pause smoothing range as a user-configurable performance setting
What changed
•	Added a new persistent setting: [PauseSmoothingRange](vscode-file://vscode-app/c:/Users/Deepro/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
o	defined in [SettingsModel.cs](vscode-file://vscode-app/c:/Users/Deepro/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
o	default value set to 0.15 (15%)
•	Updated the pause algorithm in src/Lively/Lively.Core/Suspend/Playback.cs
o	[ShouldPauseWallpaper()](vscode-file://vscode-app/c:/Users/Deepro/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now applies a smoothing hysteresis window
o	[GetPauseWeight()](vscode-file://vscode-app/c:/Users/Deepro/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now returns a gradual pause weight inside the smoothing band
o	[GetPauseSmoothingRange()](vscode-file://vscode-app/c:/Users/Deepro/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) clamps the configured value to [0, 0.5]
•	Exposed the setting through gRPC settings sync
o	added pause_smoothing_range to [settings.proto](vscode-file://vscode-app/c:/Users/Deepro/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
o	mapped the new field in [UserSettingsClient.cs](vscode-file://vscode-app/c:/Users/Deepro/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
o	persisted and returned it in [UserSettingsServer.cs](vscode-file://vscode-app/c:/Users/Deepro/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
•	Added UI controls in the Performance settings page
o	new slider in [SettingsPerformanceView.xaml](vscode-file://vscode-app/c:/Users/Deepro/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
o	bound to [PauseSmoothingRangePercent](vscode-file://vscode-app/c:/Users/Deepro/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [SettingsPerformanceViewModel.cs](vscode-file://vscode-app/c:/Users/Deepro/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
o	UI stores slider values as 0..30% and translates to normalized 0..0.30 internally
Why this change
This makes wallpaper pause behavior smoother and tunable:
•	small changes in app coverage near the pause threshold no longer flip pause/play instantly
•	users can choose a more forgiving smoothing range when they want less aggressive pause transitions
•	default behavior remains unchanged for existing users
Testing
•	Build the main app project
o	dotnet build Lively.csproj -c Release
•	Confirm the performance settings page shows:
o	[Pause smoothing](vscode-file://vscode-app/c:/Users/Deepro/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
o	0..30% slider
•	Verify adjusting the slider updates settings persistence
•	Verify pause behavior uses a hysteresis window instead of hard threshold switching
Notes
•	The UI slider is capped at 30% for usability
•	The core algorithm still clamps settings to a maximum of 50% if a value is loaded externally
•	This is primarily a behavior/settings wiring change, not a visual redesign