### PR TITLE
fix: wallpaper customise page to prevent accidental change settings b…

### DIFF
--- a/src/Lively/Lively.UI.WinUI/Views/LivelyProperty/LivelyPropertiesView.xaml
+++ b/src/Lively/Lively.UI.WinUI/Views/LivelyProperty/LivelyPropertiesView.xaml
@@ -40,6 +40,7 @@
                 Header="{Binding Text, Mode=OneWay}"
                 Maximum="{Binding Max}"
                 Minimum="{Binding Min}"
+                PointerWheelChanged="SuppressControlWheel"
                 StepFrequency="{Binding Step}"
                 ToolTipService.ToolTip="{Binding Help}"
                 Value="{Binding Value, Mode=TwoWay}" />
@@ -70,6 +71,7 @@
                 behaviors:ComboBoxSelectionChangedBehavior.CommandParameter="{Binding}"
                 Header="{Binding Text}"
                 ItemsSource="{Binding Items}"
+                PointerWheelChanged="SuppressControlWheel"
                 SelectedIndex="{Binding Value, Mode=TwoWay}"
                 ToolTipService.ToolTip="{Binding Help}" />
         </DataTemplate>

--- a/src/Lively/Lively.UI.WinUI/Views/LivelyProperty/LivelyPropertiesView.xaml.cs
+++ b/src/Lively/Lively.UI.WinUI/Views/LivelyProperty/LivelyPropertiesView.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using Lively.UI.Shared.ViewModels;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 
 namespace Lively.UI.WinUI.Views.LivelyProperty
@@ -26,6 +27,11 @@ namespace Lively.UI.WinUI.Views.LivelyProperty
         {
             this.viewModel = e.Parameter as CustomiseWallpaperViewModel;
             this.DataContext = this.viewModel;
+        }
+
+        private void SuppressControlWheel(object sender, PointerRoutedEventArgs e)
+        {
+            e.Handled = true;
         }
 
         //protected override void OnNavigatedFrom(NavigationEventArgs e)


### PR DESCRIPTION
A wallpaper with multiple configure pages always changed by mouse wheel.
Slider / DropdownList /folderDropdown will be changed accidental when scroll mouse wheel, so the  simple method is disable these type control's event function to avoid it. 
After changed this, settings works fine for me.