### PR TITLE
Remove unused Grpc.Core runtime

### DIFF
--- a/src/Lively/Lively.Grpc.Common/Lively.Grpc.Common.csproj
+++ b/src/Lively/Lively.Grpc.Common/Lively.Grpc.Common.csproj
@@ -14,8 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.33.1" />
-    <PackageReference Include="Grpc" Version="2.46.6" />
-    <PackageReference Include="Grpc.Core" Version="2.46.6" />
     <PackageReference Include="Grpc.Core.Api" Version="2.71.0" />
     <PackageReference Include="Grpc.Tools" Version="2.76.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

- Remove the unused `Grpc` and `Grpc.Core` package references.
- Keep the existing `GrpcDotNetNamedPipes` transport unchanged.

## Why

Lively already uses `GrpcDotNetNamedPipes` for both client and server IPC. The old `Grpc.Core` runtime is not used, but it brings the native `grpc_csharp_ext` library for x86/x64 and has no Windows ARM64 asset.

This removes that unused native dependency and clears one blocker for native ARM64 builds. ARM64 MSIX configuration is left for a separate change.

## Tested

- Built `Lively.Grpc.Common`, `Lively.Grpc.Client`, and `Lively`.
- Ran a generated named-pipe RPC on win-arm64 and self-contained win-x64.
- Published `Lively` for win-arm64 and win-x64; neither output contains `Grpc.Core.dll` or `grpc_csharp_ext`.